### PR TITLE
Add fonts path to asset pipeline

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -5,6 +5,7 @@ Rails.application.config.assets.version = '1.0'
 
 # Add additional assets to the asset load path
 # Rails.application.config.assets.paths << Emoji.images_path
+Rails.application.config.assets.paths << Rails.root.join("app", "assets", "fonts")
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.


### PR DESCRIPTION
Added possibility to add fonts through /app/assets/fonts/ instead of sideload-based methods.