### PR TITLE
Fontfix for macOS

### DIFF
--- a/app/assets/stylesheets/basis.scss
+++ b/app/assets/stylesheets/basis.scss
@@ -12,6 +12,8 @@ html {
 
 body {
   font: #{$base-font-size}/#{$base-line-height} $base-font;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   background-color: #fff;
   color: #000;
 }


### PR DESCRIPTION
Just a small fix to prevent fonts look bolder on macOS (and get some practice on work with Git via RubyMine). Made because of several discussions about font rendering in macOS. Commit rejection is totally acceptable. :)